### PR TITLE
updating sqlite3 version to 1.7

### DIFF
--- a/iev.gemspec
+++ b/iev.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "relaton", "~> 1.18"
   spec.add_dependency "ruby-prof"
   spec.add_dependency "sequel", "~> 5.40"
-  spec.add_dependency "sqlite3", "~> 1.4.2"
+  spec.add_dependency "sqlite3", "~> 1.7.0"
   spec.add_dependency "thor", "~> 1.0"
   spec.add_dependency "zeitwerk", "~> 2.4"
 end

--- a/spec/acceptance/db2yaml_spec.rb
+++ b/spec/acceptance/db2yaml_spec.rb
@@ -133,6 +133,8 @@ RSpec.describe "IEV" do
 
         expect(concept2).to eq(expected_concept2)
         expect(localized_concept2).to eq(expected_localized_concept2)
+
+        FileUtils.rm_rf(concepts_dir)
       end
     end
   end

--- a/spec/acceptance/xlsx2db_spec.rb
+++ b/spec/acceptance/xlsx2db_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe "IEV" do
         SQL
 
         expect(db.execute(sql).first.first).to eq("function")
+
+        FileUtils.rm_rf(dbfile)
       end
     end
   end

--- a/spec/acceptance/xlsx2db_spec.rb
+++ b/spec/acceptance/xlsx2db_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "IEV" do
 
         expect(db.execute(sql).first.first).to eq("function")
 
-        FileUtils.rm_rf(dbfile)
+        FileUtils.rm_rf Dir.glob(File.join(dir, "*"))
       end
     end
   end

--- a/spec/acceptance/xlsx2yaml_spec.rb
+++ b/spec/acceptance/xlsx2yaml_spec.rb
@@ -132,6 +132,8 @@ RSpec.describe "IEV" do
 
         expect(concept2).to eq(expected_concept2)
         expect(localized_concept2).to eq(expected_localized_concept2)
+
+        FileUtils.rm_rf(concepts_dir)
       end
     end
   end


### PR DESCRIPTION
Updated `sqlite3` version to `1.7` to fix failing specs for windows in CI.