### PR TITLE
chore: renamed all caps module names to camel case

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-= IEV
+= Iev
 
 image:https://img.shields.io/gem/v/iev.svg["Gem Version", link="https://rubygems.org/gems/iev"]
 image:https://github.com/metanorma/iev/workflows/rake/badge.svg["Build Status", link="https://github.com/metanorma/iev/actions?query=workflow%3Arake"]
@@ -6,7 +6,7 @@ image:https://codeclimate.com/github/metanorma/iev/badges/gpa.svg["Code Climate"
 image:https://img.shields.io/github/issues-pr-raw/metanorma/iev.svg["Pull Requests", link="https://github.com/metanorma/iev/pulls"]
 image:https://img.shields.io/github/commits-since/metanorma/iev/latest.svg["Commits since latest",link="https://github.com/metanorma/iev/releases"]
 
-Fetch and encode IEV term from Electropedia.
+Fetch and encode Iev term from Electropedia.
 
 == Installation
 
@@ -31,15 +31,15 @@ Or install it yourself as:
 ----
 # Get term
 
-IEV.get("103-01-02", "en")
+Iev.get("103-01-02", "en")
 => "functional"
 
 # If code not found
-IEV.get("111-11-11", "en")
+Iev.get("111-11-11", "en")
 => ""
 
 # If language not found
-IEV.get("103-01-02", "eee")
+Iev.get("103-01-02", "eee")
 => nil
 ----
 

--- a/exe/iev-glossarist
+++ b/exe/iev-glossarist
@@ -18,4 +18,4 @@ end
 require "iev"
 require "iev/cli"
 
-IEV::CLI.start(ARGV)
+Iev::Cli.start(ARGV)

--- a/iev.gemspec
+++ b/iev.gemspec
@@ -4,12 +4,12 @@ require "iev/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "iev"
-  spec.version       = IEV::VERSION
+  spec.version       = Iev::VERSION
   spec.authors       = ["Ribose Inc."]
   spec.email         = ["open.source@ribose.com"]
 
-  spec.summary       = "IEV: Fetch and encode IEV term from Electropedia"
-  spec.description   = "IEV: Fetch and encode IEV term from Electropedia"
+  spec.summary       = "Iev: Fetch and encode Iev term from Electropedia"
+  spec.description   = "Iev: Fetch and encode Iev term from Electropedia"
   spec.homepage      = "https://github.com/metanorma/iev"
   spec.license       = "BSD-2-Clause"
 

--- a/lib/iev.rb
+++ b/lib/iev.rb
@@ -16,14 +16,9 @@ require "yaml"
 require "zeitwerk"
 
 loader = Zeitwerk::Loader.for_gem
-loader.inflector.inflect(
-  "cli" => "CLI",
-  "iev" => "IEV",
-  "ui" => "UI",
-)
 loader.setup
 
-module IEV
+module Iev
   #
   # Scrape Electropedia for term.
   #

--- a/lib/iev/cli.rb
+++ b/lib/iev/cli.rb
@@ -3,20 +3,20 @@
 # (c) Copyright 2020 Ribose Inc.
 #
 
-module IEV
-  module CLI
+module Iev
+  module Cli
     def self.start(arguments)
       Signal.trap("INT") do
-        UI.info "Signal SIGINT received, quitting!"
+        Ui.info "Signal SIGINT received, quitting!"
         Kernel.exit(1)
       end
 
       Signal.trap("TERM") do
-        UI.info "Signal SIGTERM received, quitting!"
+        Ui.info "Signal SIGTERM received, quitting!"
         Kernel.exit(1)
       end
 
-      IEV::CLI::Command.start(arguments)
+      Iev::Cli::Command.start(arguments)
     end
   end
 end

--- a/lib/iev/cli/command.rb
+++ b/lib/iev/cli/command.rb
@@ -3,8 +3,8 @@
 # (c) Copyright 2020 Ribose Inc.
 #
 
-module IEV
-  module CLI
+module Iev
+  module Cli
     class Command < Thor
       include CommandHelper
 

--- a/lib/iev/cli/command_helper.rb
+++ b/lib/iev/cli/command_helper.rb
@@ -3,10 +3,10 @@
 # (c) Copyright 2020 Ribose Inc.
 #
 
-module IEV
-  module CLI
+module Iev
+  module Cli
     module CommandHelper
-      include CLI::UI
+      include Cli::Ui
 
       protected
 

--- a/lib/iev/cli/ui.rb
+++ b/lib/iev/cli/ui.rb
@@ -3,13 +3,13 @@
 # (c) Copyright 2020 Ribose Inc.
 #
 
-module IEV
-  module CLI
+module Iev
+  module Cli
     # @todo
     #   Make it thread-safe.  Currently, calling UI methods from different
     #   threads may result with mangled output.  At first glance it seems like
     #   something is wrong with carriage returns, but more research is needed.
-    module UI
+    module Ui
       module_function
 
       def debug(*args)

--- a/lib/iev/converter.rb
+++ b/lib/iev/converter.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-module IEV
+module Iev
   module Converter
     def self.mathml_to_asciimath(input)
-      IEV::Converter::MathmlToAsciimath.convert(input)
+      Iev::Converter::MathmlToAsciimath.convert(input)
     end
   end
 end

--- a/lib/iev/converter/mathml_to_asciimath.rb
+++ b/lib/iev/converter/mathml_to_asciimath.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module IEV
+module Iev
   module Converter
     class MathmlToAsciimath
       using DataConversions

--- a/lib/iev/data_conversions.rb
+++ b/lib/iev/data_conversions.rb
@@ -3,7 +3,7 @@
 # (c) Copyright 2020 Ribose Inc.
 #
 
-module IEV
+module Iev
   module DataConversions
     refine String do
       def decode_html!
@@ -32,7 +32,7 @@ module IEV
       end
 
       def to_three_char_code
-        IEV::Iso639Code.three_char_code(self).first
+        Iev::Iso639Code.three_char_code(self).first
       end
     end
   end

--- a/lib/iev/db.rb
+++ b/lib/iev/db.rb
@@ -1,7 +1,7 @@
 # require 'pstore'
 require_relative "db_cache"
 
-module IEV
+module Iev
   # Cache class.
   class Db
     # @param global_cache [String] filename of global DB
@@ -43,12 +43,12 @@ module IEV
 
     # @return [Hash]
     def new_bib_entry(code, lang)
-      IEV.get(code, lang)
+      Iev.get(code, lang)
     end
 
     # @param dir [String] DB dir
     # @param global [TrueClass, FalseClass]
-    # @return [IEV::DbCache, nil]
+    # @return [Iev::DbCache, nil]
     def open_cache_biblio(dir, global: true)
       return nil if dir.nil?
 

--- a/lib/iev/db_cache.rb
+++ b/lib/iev/db_cache.rb
@@ -1,6 +1,6 @@
 require "fileutils"
 
-module IEV
+module Iev
   class DbCache
     # @return [String]
     attr_reader :dir
@@ -73,7 +73,7 @@ module IEV
     end
 
     # Set version of the DB to the gem version.
-    # @return [IEV::DbCache]
+    # @return [Iev::DbCache]
     def set_version
       File.write "#{@dir}/version", VERSION, encoding: "utf-8"
       self

--- a/lib/iev/db_writer.rb
+++ b/lib/iev/db_writer.rb
@@ -3,9 +3,9 @@
 # (c) Copyright 2020 Ribose Inc.
 #
 
-module IEV
+module Iev
   class DbWriter
-    include CLI::UI
+    include Cli::Ui
     using DataConversions
 
     attr_reader :db

--- a/lib/iev/iso_639_code.rb
+++ b/lib/iev/iso_639_code.rb
@@ -3,7 +3,7 @@
 # (c) Copyright 2020 Ribose Inc.
 #
 
-module IEV
+module Iev
   # @todo This needs to be rewritten.
   class Iso639Code
     COUNTRY_CODES = YAML.load(IO.read(File.join(__dir__, "iso_639_2.yaml")))
@@ -14,7 +14,7 @@ module IEV
       when 2
         two_char_code
       else
-        # This is to handle code "nl BE" in the IEV sheet
+        # This is to handle code "nl BE" in the Iev sheet
         two_char_code.split(" ").first
       end
     end

--- a/lib/iev/profiler.rb
+++ b/lib/iev/profiler.rb
@@ -3,7 +3,7 @@
 # (c) Copyright 2020 Ribose Inc.
 #
 
-module IEV
+module Iev
   class Profiler
     attr_reader :bench, :dir, :prefix, :profile
 

--- a/lib/iev/relaton_db.rb
+++ b/lib/iev/relaton_db.rb
@@ -5,11 +5,11 @@
 
 require "singleton"
 
-module IEV
+module Iev
   # Relaton cach singleton.
   class RelatonDb
     include Singleton
-    include CLI::UI
+    include Cli::Ui
 
     def initialize
       info "Initializing Relaton..."

--- a/lib/iev/source_parser.rb
+++ b/lib/iev/source_parser.rb
@@ -5,13 +5,13 @@
 
 # rubocop:todo Style/RedundantRegexpEscape
 
-module IEV
+module Iev
   # Parses information from the spreadsheet's SOURCE column.
   #
   # @example
   #   SourceParser.new(cell_data_string).parsed_sources
   class SourceParser
-    include CLI::UI
+    include Cli::Ui
     include Utilities
     using DataConversions
 
@@ -79,7 +79,7 @@ module IEV
         "clause" => clause,
         "link" => obtain_source_link(source_ref),
         "relationship" => relation_type,
-        "original" => IEV::Converter.mathml_to_asciimath(
+        "original" => Iev::Converter.mathml_to_asciimath(
           parse_anchor_tag(raw_ref, @term_domain),
         ),
       }.compact
@@ -329,7 +329,7 @@ module IEV
       when /(modified|modifié|modifiée|modifiés|MOD)\s*[–-]?\s+(.+)\Z/
         {
           "type" => type.to_s,
-          "modification" => IEV::Converter.mathml_to_asciimath(
+          "modification" => Iev::Converter.mathml_to_asciimath(
             parse_anchor_tag($2, @term_domain),
           ).strip,
         }

--- a/lib/iev/supersession_parser.rb
+++ b/lib/iev/supersession_parser.rb
@@ -3,13 +3,13 @@
 # (c) Copyright 2020 Ribose Inc.
 #
 
-module IEV
+module Iev
   # Parses information from the spreadsheet's REPLACES column.
   #
   # @example
   #   SupersessionParser.new(cell_data_string).supersessions
   class SupersessionParser
-    include CLI::UI
+    include Cli::Ui
     using DataConversions
 
     attr_reader :raw_str, :src_str

--- a/lib/iev/term_attrs_parser.rb
+++ b/lib/iev/term_attrs_parser.rb
@@ -3,7 +3,7 @@
 # (c) Copyright 2020 Ribose Inc.
 #
 
-module IEV
+module Iev
   # Parses information from the spreadsheet's TERMATTRIBUTE column and alike.
   #
   # @example
@@ -12,7 +12,7 @@ module IEV
   #   parser.plurality # returns grammatical plurality
   #   parser.part_of_speech # returns part of speech
   class TermAttrsParser
-    include CLI::UI
+    include Cli::Ui
     using DataConversions
 
     attr_reader :raw_str, :src_str

--- a/lib/iev/term_builder.rb
+++ b/lib/iev/term_builder.rb
@@ -5,9 +5,9 @@
 
 require "pp"
 
-module IEV
+module Iev
   class TermBuilder
-    include CLI::UI
+    include Cli::Ui
     include Utilities
     using DataConversions
 
@@ -209,7 +209,7 @@ module IEV
 
     def extract_definition_value
       if @definition
-        IEV::Converter.mathml_to_asciimath(
+        Iev::Converter.mathml_to_asciimath(
           replace_newlines(parse_anchor_tag(@definition, term_domain)),
         ).strip
       end
@@ -217,7 +217,7 @@ module IEV
 
     def extract_examples
       @examples.map do |str|
-        IEV::Converter.mathml_to_asciimath(
+        Iev::Converter.mathml_to_asciimath(
           replace_newlines(parse_anchor_tag(str, term_domain)),
         ).strip
       end
@@ -225,7 +225,7 @@ module IEV
 
     def extract_notes
       @notes.map do |str|
-        IEV::Converter.mathml_to_asciimath(
+        Iev::Converter.mathml_to_asciimath(
           replace_newlines(parse_anchor_tag(str, term_domain)),
         ).strip
       end
@@ -275,7 +275,7 @@ module IEV
     private
 
     def build_expression_designation(raw_term, attribute_data:, status:)
-      term = IEV::Converter.mathml_to_asciimath(
+      term = Iev::Converter.mathml_to_asciimath(
         parse_anchor_tag(raw_term, term_domain),
       )
       term_attributes = TermAttrsParser.new(attribute_data.to_s)
@@ -299,7 +299,7 @@ module IEV
     end
 
     def build_symbol_designation(raw_term)
-      term = IEV::Converter.mathml_to_asciimath(
+      term = Iev::Converter.mathml_to_asciimath(
         parse_anchor_tag(raw_term, term_domain),
       )
 

--- a/lib/iev/utilities.rb
+++ b/lib/iev/utilities.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module IEV
+module Iev
   module Utilities
     SIMG_PATH_REGEX = "<simg .*\\/\\$file\\/([\\d\\-\\w\.]+)>"
     FIGURE_ONE_REGEX =

--- a/lib/iev/version.rb
+++ b/lib/iev/version.rb
@@ -1,3 +1,3 @@
-module IEV
+module Iev
   VERSION = "0.3.4".freeze
 end

--- a/spec/acceptance/db2yaml_spec.rb
+++ b/spec/acceptance/db2yaml_spec.rb
@@ -4,7 +4,7 @@
 require "spec_helper"
 require "yaml"
 
-RSpec.describe "IEV" do
+RSpec.describe "Iev" do
   let(:sample_db) { fixture_path("sample-db.sqlite3") }
 
   describe "db2yaml" do
@@ -99,7 +99,7 @@ RSpec.describe "IEV" do
     it "exports YAMLs from given database" do
       Dir.mktmpdir("iev-test") do |dir|
         command = %W(db2yaml #{sample_db} -o #{dir})
-        silence_output_streams { IEV::CLI.start(command) }
+        silence_output_streams { Iev::Cli.start(command) }
 
         concepts_dir = File.join(dir, "concepts")
         expect(concepts_dir).to satisfy { |p| File.directory? p }

--- a/spec/acceptance/xlsx2db_spec.rb
+++ b/spec/acceptance/xlsx2db_spec.rb
@@ -3,7 +3,7 @@
 
 require "spec_helper"
 
-RSpec.describe "IEV" do
+RSpec.describe "Iev" do
   let(:sample_xlsx_file) { fixture_path("sample-file.xlsx") }
   let(:tmp_db_dir) { "tmp-db-dir" }
 
@@ -15,7 +15,7 @@ RSpec.describe "IEV" do
 
       dbfile = File.join(tmp_db_dir, "test.sqlite3")
       command = %W(xlsx2db #{sample_xlsx_file} -o #{dbfile})
-      silence_output_streams { IEV::CLI.start(command) }
+      silence_output_streams { Iev::Cli.start(command) }
 
       expect(dbfile).to satisfy { |p| File.file? p }
 

--- a/spec/acceptance/xlsx2yaml_spec.rb
+++ b/spec/acceptance/xlsx2yaml_spec.rb
@@ -3,7 +3,7 @@
 
 require "spec_helper"
 
-RSpec.describe "IEV" do
+RSpec.describe "Iev" do
   let(:sample_xlsx_file) { fixture_path("sample-file.xlsx") }
 
   describe "xlsx2yaml" do
@@ -98,7 +98,7 @@ RSpec.describe "IEV" do
     it "exports YAMLs from given XLSX document" do
       Dir.mktmpdir("iev-test") do |dir|
         command = %W(xlsx2yaml #{sample_xlsx_file} -o #{dir})
-        silence_output_streams { IEV::CLI.start(command) }
+        silence_output_streams { Iev::Cli.start(command) }
 
         concepts_dir = File.join(dir, "concepts")
         expect(concepts_dir).to satisfy { |p| File.directory? p }

--- a/spec/iev/data_conversions_spec.rb
+++ b/spec/iev/data_conversions_spec.rb
@@ -4,7 +4,7 @@
 require "spec_helper"
 
 RSpec.describe "string conversion refinements" do
-  using IEV::DataConversions
+  using Iev::DataConversions
 
   describe "#decode_html" do
     it "decodes HTML entities" do

--- a/spec/iev/db_writer_spec.rb
+++ b/spec/iev/db_writer_spec.rb
@@ -3,7 +3,7 @@
 
 require "spec_helper"
 
-RSpec.describe IEV::DbWriter do
+RSpec.describe Iev::DbWriter do
   let(:instance) { described_class.new(db) }
   let(:db) { Sequel.sqlite }
   let(:sample_file) { fixture_path("sample-file.xlsx") }

--- a/spec/iev/source_parser_spec.rb
+++ b/spec/iev/source_parser_spec.rb
@@ -3,7 +3,7 @@
 
 require "spec_helper"
 
-RSpec.describe IEV::SourceParser do
+RSpec.describe Iev::SourceParser do
   subject do
     example = RSpec.current_example
     attributes_str = example.metadata[:string] || example.description

--- a/spec/iev/supersession_parser_spec.rb
+++ b/spec/iev/supersession_parser_spec.rb
@@ -3,7 +3,7 @@
 
 require "spec_helper"
 
-RSpec.describe IEV::SupersessionParser do
+RSpec.describe Iev::SupersessionParser do
   # Parses :string metadata or example description.
   subject do
     example = RSpec.current_example

--- a/spec/iev/term_attrs_parser_spec.rb
+++ b/spec/iev/term_attrs_parser_spec.rb
@@ -1,7 +1,7 @@
 # (c) Copyright 2020 Ribose Inc.
 #
 
-RSpec.describe IEV::TermAttrsParser do
+RSpec.describe Iev::TermAttrsParser do
   # Parses :string metadata or example description.
   subject do
     example = RSpec.current_example

--- a/spec/iev/term_builder_spec.rb
+++ b/spec/iev/term_builder_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe IEV::TermBuilder do
+RSpec.describe Iev::TermBuilder do
   subject { described_class.new({}) }
 
   describe "#flesh_date" do

--- a/spec/iev/utilities_spec.rb
+++ b/spec/iev/utilities_spec.rb
@@ -3,10 +3,10 @@
 require "spec_helper"
 
 class TestUtilites
-  include IEV::Utilities
+  include Iev::Utilities
 end
 
-RSpec.describe IEV::Utilities do
+RSpec.describe Iev::Utilities do
   subject { TestUtilites.new }
 
   describe "#parse_anchor_tag" do

--- a/spec/iev_spec.rb
+++ b/spec/iev_spec.rb
@@ -1,11 +1,11 @@
-RSpec.describe IEV do
+RSpec.describe Iev do
   before :each do
     FileUtils.rm_rf %w(testcache testcache2)
-    @db = IEV::Db.new "testcache", "testcache2"
+    @db = Iev::Db.new "testcache", "testcache2"
   end
 
   it "has a version number" do
-    expect(IEV::VERSION).not_to be nil
+    expect(Iev::VERSION).not_to be nil
   end
 
   it "get term, cache it and return" do
@@ -52,8 +52,8 @@ RSpec.describe IEV do
     mock_open_uri("103-01-02")
     @db.fetch "103-01-02", "en"
     expect(@db.instance_variable_get(:@db).all.any?).to be_truthy
-    stub_const "IEV::VERSION", "new_version"
-    db = IEV::Db.new "testcache", "testcache2"
+    stub_const "Iev::VERSION", "new_version"
+    db = Iev::Db.new "testcache", "testcache2"
     testcache = db.instance_variable_get :@db
     expect(testcache.all.any?).to be_falsey
     testcache = db.instance_variable_get :@local_db
@@ -78,9 +78,9 @@ RSpec.describe IEV do
     testcache["test key"] = "test value"
     expect(testcache["test key"]).to eq "test value"
     expect(testcache["not existed key"]).to be_nil
-    testcache = IEV::DbCache.new "testcache"
+    testcache = Iev::DbCache.new "testcache"
     testcache.delete("test_key")
-    testcache2 = IEV::DbCache.new "testcache2"
+    testcache2 = Iev::DbCache.new "testcache2"
     testcache2.delete("test_key")
     expect(testcache["test key"]).to be_nil
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,8 +16,8 @@ RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 
-  config.include IEV::ConsoleHelper
-  config.include IEV::FixtureHelper
+  config.include Iev::ConsoleHelper
+  config.include Iev::FixtureHelper
 
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/support/console_helper.rb
+++ b/spec/support/console_helper.rb
@@ -1,7 +1,7 @@
 # (c) Copyright 2020 Ribose Inc.
 #
 
-module IEV
+module Iev
   module ConsoleHelper
     # Executes given block.  Anything written to $stdout or $stderr in that
     # block is captured and returned.

--- a/spec/support/fixture_helper.rb
+++ b/spec/support/fixture_helper.rb
@@ -1,7 +1,7 @@
 # (c) Copyright 2020 Ribose Inc.
 #
 
-module IEV
+module Iev
   module FixtureHelper
     def fixture_path(fixture_name)
       File.expand_path(fixture_name, fixture_root)


### PR DESCRIPTION
Renamed the following modules 
- `IEV` => `Iev` 
- `CLI` => `Cli`
- `UI` => `Ui`

fixes #36 