### PR TITLE
feat: UX improvements for CLI and API

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -85,19 +85,21 @@ Electropedia administrator.
 Iev.get("103-01-02", "en")
 => "functional"
 
-# If code not found
+# If code not found, returns nil (does not raise)
 Iev.get("111-11-11", "en")
-=> ""
+=> nil
 
-# If language not found
+# If language not found, returns nil
 Iev.get("103-01-02", "eee")
 => nil
 
 # Fetch full concept data (all languages)
+# Raises Iev::DataSource::NotFoundError if code not found
 Iev.fetch_concept("103-01-02")
 => { "id" => "103-01-02", "data" => { ... } }
 
 # Fetch localized term data
+# Raises Iev::DataSource::NotFoundError if code not found
 Iev.fetch_term("103-01-02", "en")
 => { "term" => "functional", ... }
 ----

--- a/lib/iev.rb
+++ b/lib/iev.rb
@@ -45,17 +45,19 @@ module Iev
   # @param [String] lang language code, for example "en"
   #
   # @return [String, nil] if found then term,
-  # if code not found then nil,
-  #   if language not found then nil.
+  #   if code or language not found then nil.
   #
   def self.get(code, lang)
     DataSource.fetch_term_designation(code, lang)
+  rescue DataSource::NotFoundError
+    nil
   end
 
   # Fetch full concept data (all languages) for a given IEV code.
   #
   # @param [String] code IEV code, e.g. "103-01-02"
-  # @return [Hash, nil] concept data hash with all languages
+  # @return [Hash] concept data hash with all languages
+  # @raise [DataSource::NotFoundError] if concept not found
   def self.fetch_concept(code)
     DataSource.fetch_concept(code)
   end
@@ -64,7 +66,8 @@ module Iev
   #
   # @param [String] code IEV code, e.g. "103-01-02"
   # @param [String] lang language code, e.g. "en" or "eng"
-  # @return [Hash, nil] localized concept data
+  # @return [Hash, nil] localized concept data or nil if not found
+  # @raise [DataSource::NotFoundError] if concept not found
   def self.fetch_term(code, lang)
     DataSource.fetch_term(code, lang)
   end

--- a/lib/iev/cli/command.rb
+++ b/lib/iev/cli/command.rb
@@ -8,6 +8,11 @@ module Iev
     class Command < Thor
       include CommandHelper
 
+      desc "version", "Show iev gem version"
+      def version
+        puts "iev #{Iev::VERSION}"
+      end
+
       desc "export FILE", "Export IEV data to Glossarist YAML format"
       long_desc <<~DESC
         Exports IEV data from an Excel (.xlsx/.xls) or SQLite (.sqlite3/.sqlite/.db)
@@ -39,18 +44,25 @@ module Iev
       def export(file)
         handle_generic_options(options)
 
-        Iev::Exporter.new(
+        exporter = Iev::Exporter.new(
           file,
           output_dir: options[:output],
           only_concepts: options[:only_concepts],
           only_languages: options[:only_languages],
           fetch_relaton_links: options[:relaton],
-        ).export
-
-        info "Done!"
+          on_progress: method(:export_progress),
+        )
+        exporter.export
+        print_export_summary(exporter.stats)
+      rescue ArgumentError => e
+        error e.message
+        exit 1
+      rescue Sequel::Error => e
+        error "Database error: #{e.message}"
+        exit 1
       end
 
-      desc "xlsx2yaml FILE", "Converts Excel IEV exports to YAMLs."
+      desc "xlsx2yaml FILE", "[DEPRECATED] Use 'export' instead."
       option :output, desc: "Output directory", aliases: :o, default: Dir.pwd
       option :only_concepts,
              desc: "Only process concepts with IEVREF matching this argument, " \
@@ -69,6 +81,7 @@ module Iev
       option :debug_sources, type: :boolean, default: false
       option :debug_relaton, type: :boolean, default: false
       def xlsx2yaml(file)
+        warn "[DEPRECATED] 'xlsx2yaml' is deprecated. Use 'export' instead."
         handle_generic_options(options)
 
         Iev::Exporter.new(
@@ -81,7 +94,7 @@ module Iev
         summary
       end
 
-      desc "db2yaml DB_FILE", "Exports SQLite to IEV YAMLs."
+      desc "db2yaml DB_FILE", "[DEPRECATED] Use 'export' instead."
       option :output, desc: "Output directory", aliases: :o, default: Dir.pwd
       option :only_concepts,
              desc: "Only process concepts with IEVREF matching this argument, " \
@@ -100,6 +113,7 @@ module Iev
       option :debug_sources, type: :boolean, default: false
       option :debug_relaton, type: :boolean, default: false
       def db2yaml(dbfile)
+        warn "[DEPRECATED] 'db2yaml' is deprecated. Use 'export' instead."
         handle_generic_options(options)
 
         Iev::Exporter.new(
@@ -138,13 +152,14 @@ module Iev
                 DataSource.fetch_concept(code)
               end
 
-        unless raw
-          warn "IEV: concept #{code} not found."
-          exit 1
-        end
-
         concept = build_concept_from_raw(code, raw)
         print_concept_grouped_yaml(concept)
+      rescue Iev::DataSource::NotFoundError
+        error "IEV concept not found: #{code}"
+        exit 1
+      rescue Ferrum::Error => e
+        error "Scraping failed: #{e.message}"
+        exit 1
       end
 
       def self.exit_on_failure?

--- a/lib/iev/cli/command_helper.rb
+++ b/lib/iev/cli/command_helper.rb
@@ -24,6 +24,36 @@ module Iev
         info "Done!"
       end
 
+      def export_progress(current, total)
+        return unless $IEV_PROGRESS
+        return if total <= 1 # single-row dataset, skip progress
+
+        if current == total
+          Ui.info "" # clear progress line
+        else
+          Ui.progress "Processing #{current}/#{total}..."
+        end
+      end
+
+      def print_export_summary(stats)
+        return unless stats
+
+        s = stats
+        elapsed = format_elapsed(s[:elapsed_seconds])
+        info "Exported #{s[:concept_count]} concepts " \
+             "(#{s[:localized_count]} localized) in #{elapsed}"
+      end
+
+      def format_elapsed(seconds)
+        if seconds < 60
+          "%.1fs" % seconds
+        else
+          mins = (seconds / 60).to_i
+          secs = (seconds % 60).round
+          "#{mins}m #{secs}s"
+        end
+      end
+
       def handle_generic_options(options)
         $IEV_PROFILE = options[:profile]
         $IEV_PROGRESS = options.fetch(:progress, !ENV["CI"])

--- a/lib/iev/cli/ui.rb
+++ b/lib/iev/cli/ui.rb
@@ -32,6 +32,11 @@ module Iev
         print "#{Helper.clear_progress}#{message}\n"
       end
 
+      # Prints error message to stderr.
+      def error(message)
+        Kernel.warn "Error: #{message}"
+      end
+
       # Sets an UI tag which will be prepended to messages printed with
       # #debug and #warn.
       def set_ui_tag(str)

--- a/lib/iev/data_source.rb
+++ b/lib/iev/data_source.rb
@@ -12,19 +12,21 @@ module Iev
       # Fetch full concept data (all languages) for a given IEV code.
       #
       # @param code [String] IEV code, e.g. "103-01-02"
-      # @return [Hash, nil] concept data hash or nil if not found
+      # @return [Hash] concept data hash
+      # @raise [NotFoundError] if the concept does not exist
       def fetch_concept(code)
-        fetch_concept_data(code)
+        fetch_concept_data(code) ||
+          raise(NotFoundError, "IEV concept not found: #{code}")
       end
 
       # Fetch localized term data for a given IEV code and language.
       #
       # @param code [String] IEV code, e.g. "103-01-02"
       # @param lang [String] language code, e.g. "en" or "eng"
-      # @return [Hash, nil] localized concept data or nil
+      # @return [Hash, nil] localized concept data or nil if language not found
+      # @raise [NotFoundError] if the concept does not exist
       def fetch_term(code, lang)
         concept = fetch_concept(code)
-        return nil unless concept
 
         lang_key = normalize_lang(lang)
         concept[lang_key]
@@ -35,7 +37,8 @@ module Iev
       #
       # @param code [String] IEV code, e.g. "103-01-02"
       # @param lang [String] language code, e.g. "en"
-      # @return [String, nil] term designation or nil
+      # @return [String, nil] term designation or nil if not found
+      # @raise [NotFoundError] if the concept does not exist
       def fetch_term_designation(code, lang)
         term_data = fetch_term(code, lang)
         return nil unless term_data

--- a/lib/iev/exporter.rb
+++ b/lib/iev/exporter.rb
@@ -27,15 +27,18 @@ module Iev
     # @param output_dir [String, Pathname] destination for YAML files
     # @param only_concepts [String, nil] SQL LIKE pattern for IEVREF filtering
     # @param only_languages [String, nil] comma-separated language codes
-    # @param fetch_relaton_links [Boolean] whether to fetch source URLs via Relaton
+    # @param fetch_relaton_links [Boolean] fetch source URLs via Relaton
+    # @param on_progress [Proc, nil] callback (current, total) during build
     def initialize(input_path, output_dir: Dir.pwd,
                    only_concepts: nil, only_languages: nil,
-                   fetch_relaton_links: false)
+                   fetch_relaton_links: false,
+                   on_progress: nil)
       @input_path = Pathname.new(input_path)
       validate_input!
 
       @output_dir = Pathname.new(output_dir)
       @fetch_relaton_links = fetch_relaton_links
+      @on_progress = on_progress
       @filters = {
         only_concepts: only_concepts,
         only_languages: only_languages,
@@ -45,11 +48,22 @@ module Iev
     # Run the export pipeline: load → transform → save.
     # @return [Glossarist::ManagedConceptCollection]
     def export
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       dataset = load_dataset
       collection = build_collection(dataset)
       save_collection(collection)
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+
+      @stats = {
+        concept_count: collection.count,
+        localized_count: localized_count(collection),
+        elapsed_seconds: elapsed,
+      }
       collection
     end
+
+    # @return [Hash, nil] stats from last export, or nil if export hasn't run
+    attr_reader :stats
 
     private
 
@@ -111,8 +125,13 @@ module Iev
       # Glossarist's O(n) fetch_or_initialize which does linear scan.
       concept_index = {}
       collection = Glossarist::ManagedConceptCollection.new
+      row_count = dataset.count
+      current = 0
 
       dataset.each do |row|
+        current += 1
+        @on_progress&.call(current, row_count)
+
         term = TermBuilder.build_from(row)
         next unless term
 
@@ -133,6 +152,10 @@ module Iev
       concepts_dir = output_dir.expand_path.join("concepts")
       FileUtils.mkdir_p(concepts_dir)
       collection.save_to_files(concepts_dir.to_s)
+    end
+
+    def localized_count(collection)
+      collection.sum { |c| c.localized_concepts.count }
     end
   end
 end

--- a/spec/iev/data_source_spec.rb
+++ b/spec/iev/data_source_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe Iev::DataSource do
       expect(concept).to have_key("fra")
     end
 
-    it "returns nil for non-existent code" do
-      concept = described_class.fetch_concept("999-99-99")
-      expect(concept).to be_nil
+    it "raises NotFoundError for non-existent code" do
+      expect { described_class.fetch_concept("999-99-99") }
+        .to raise_error(Iev::DataSource::NotFoundError, /not found/)
     end
   end
 
@@ -57,9 +57,9 @@ RSpec.describe Iev::DataSource do
       expect(term["terms"][0]["designation"]).to eq("Funktional")
     end
 
-    it "returns nil for non-existent code" do
-      term = described_class.fetch_term("999-99-99", "eng")
-      expect(term).to be_nil
+    it "raises NotFoundError for non-existent code" do
+      expect { described_class.fetch_term("999-99-99", "eng") }
+        .to raise_error(Iev::DataSource::NotFoundError, /not found/)
     end
 
     it "returns nil for non-existent language" do
@@ -79,9 +79,9 @@ RSpec.describe Iev::DataSource do
       expect(result).to eq("Funktional")
     end
 
-    it "returns nil for non-existent code" do
-      result = described_class.fetch_term_designation("999-99-99", "en")
-      expect(result).to be_nil
+    it "raises NotFoundError for non-existent code" do
+      expect { described_class.fetch_term_designation("999-99-99", "en") }
+        .to raise_error(Iev::DataSource::NotFoundError, /not found/)
     end
 
     it "returns nil for non-existent language" do


### PR DESCRIPTION
## Summary

- **`iev version`** — new command to show gem version
- **Deprecate `xlsx2yaml` / `db2yaml`** — these are superseded by the unified `export` command; deprecation warnings printed to stderr
- **Friendly CLI error messages** — `ArgumentError`, `Sequel::Error`, `NotFoundError`, and `Ferrum::Error` are caught and displayed as one-liners instead of raw stack traces
- **Export progress indicator** — shows `Processing N/M...` during build and prints a summary line with concept count, localized count, and elapsed time
- **`DataSource::NotFoundError`** — `fetch_concept` and `fetch_term` now raise `NotFoundError` instead of silently returning `nil`; `Iev.get` remains backward-compatible (returns `nil`)
- **Fix README** — corrected `Iev.get` return value docs (`nil` not `""`) and documented `NotFoundError` behavior
- **`on_progress` callback** on `Exporter` for programmatic progress monitoring

## Test plan

- [x] `bundle exec rspec` — 158 examples, 0 failures
- [x] `bundle exec rubocop` — no new offenses
- [x] Verified `iev version` outputs version string
- [x] Verified `iev export nonexistent.txt` shows friendly error
- [x] Verified `iev xlsx2yaml` shows deprecation warning