### PR TITLE
Use URN syntax for IEV concept mentions

### DIFF
--- a/lib/iev/utilities.rb
+++ b/lib/iev/utilities.rb
@@ -134,7 +134,7 @@ module Iev
 
       if href.match?(IEV_CODE_RE)
         iev_code = href.sub(/\AIEV\s*/, "")
-        "{{#{inner}, IEV:#{iev_code}}}"
+        "{{#{inner}, urn:iec:std:iec:60050-#{iev_code}}}"
       elsif !href.empty?
         "#{href}[#{inner}]"
       else

--- a/spec/acceptance/db2yaml_spec.rb
+++ b/spec/acceptance/db2yaml_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe "Iev" do
           "localized_concepts" => {
             "ara" => "2facc2da-b31c-5865-a461-7b09beb50306",
             "deu" => "b428bdb9-caae-56e2-843e-fc235e237caf",
-            "eng" => "fb47471b-2692-5075-b273-b3f671e9ca9f",
-            "fra" => "c390520c-2eab-540e-bf70-bfa68a5a5d71",
+            "eng" => "7ed95403-bf50-5441-8390-d0212000fde0",
+            "fra" => "82febf21-e705-5eca-b924-8df37f174c29",
             "jpn" => "26880cae-c119-53f2-bd78-41c717173a69",
             "kor" => "9545c889-80f7-5662-8880-d8036a6c0378",
             "pol" => "3c3c4681-28c1-5df5-9c53-64f862750686",
@@ -45,7 +45,7 @@ RSpec.describe "Iev" do
           ],
           "definition" => [
             {
-              "content" => "See {{IEV 102-01-10, IEV:102-01-10}}",
+              "content" => "See {{IEV 102-01-10, urn:iec:std:iec:60050-102-01-10}}",
             },
           ],
           "examples" => [],
@@ -75,7 +75,7 @@ RSpec.describe "Iev" do
           "review_decision_event" => "published",
         },
         "date_accepted" => "2017-07-01T00:00:00+00:00",
-        "id" => "fb47471b-2692-5075-b273-b3f671e9ca9f",
+        "id" => "7ed95403-bf50-5441-8390-d0212000fde0",
       }
     end
 

--- a/spec/acceptance/export_spec.rb
+++ b/spec/acceptance/export_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe "Iev" do
           "localized_concepts" => {
             "ara" => "2facc2da-b31c-5865-a461-7b09beb50306",
             "deu" => "b428bdb9-caae-56e2-843e-fc235e237caf",
-            "eng" => "fb47471b-2692-5075-b273-b3f671e9ca9f",
-            "fra" => "c390520c-2eab-540e-bf70-bfa68a5a5d71",
+            "eng" => "7ed95403-bf50-5441-8390-d0212000fde0",
+            "fra" => "82febf21-e705-5eca-b924-8df37f174c29",
             "jpn" => "26880cae-c119-53f2-bd78-41c717173a69",
             "kor" => "9545c889-80f7-5662-8880-d8036a6c0378",
             "pol" => "3c3c4681-28c1-5df5-9c53-64f862750686",
@@ -43,7 +43,7 @@ RSpec.describe "Iev" do
           ],
           "definition" => [
             {
-              "content" => "See {{IEV 102-01-10, IEV:102-01-10}}",
+              "content" => "See {{IEV 102-01-10, urn:iec:std:iec:60050-102-01-10}}",
             },
           ],
           "examples" => [],
@@ -73,7 +73,7 @@ RSpec.describe "Iev" do
           "review_decision_event" => "published",
         },
         "date_accepted" => "2017-07-01T00:00:00+00:00",
-        "id" => "fb47471b-2692-5075-b273-b3f671e9ca9f",
+        "id" => "7ed95403-bf50-5441-8390-d0212000fde0",
       }
     end
 

--- a/spec/acceptance/xlsx2yaml_spec.rb
+++ b/spec/acceptance/xlsx2yaml_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe "Iev" do
           "localized_concepts" => {
             "ara" => "2facc2da-b31c-5865-a461-7b09beb50306",
             "deu" => "b428bdb9-caae-56e2-843e-fc235e237caf",
-            "eng" => "fb47471b-2692-5075-b273-b3f671e9ca9f",
-            "fra" => "c390520c-2eab-540e-bf70-bfa68a5a5d71",
+            "eng" => "7ed95403-bf50-5441-8390-d0212000fde0",
+            "fra" => "82febf21-e705-5eca-b924-8df37f174c29",
             "jpn" => "26880cae-c119-53f2-bd78-41c717173a69",
             "kor" => "9545c889-80f7-5662-8880-d8036a6c0378",
             "pol" => "3c3c4681-28c1-5df5-9c53-64f862750686",
@@ -44,7 +44,7 @@ RSpec.describe "Iev" do
           ],
           "definition" => [
             {
-              "content" => "See {{IEV 102-01-10, IEV:102-01-10}}",
+              "content" => "See {{IEV 102-01-10, urn:iec:std:iec:60050-102-01-10}}",
             },
           ],
           "examples" => [],
@@ -74,7 +74,7 @@ RSpec.describe "Iev" do
           "review_decision_event" => "published",
         },
         "date_accepted" => "2017-07-01T00:00:00+00:00",
-        "id" => "fb47471b-2692-5075-b273-b3f671e9ca9f",
+        "id" => "7ed95403-bf50-5441-8390-d0212000fde0",
       }
     end
 

--- a/spec/iev/utilities_spec.rb
+++ b/spec/iev/utilities_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe Iev::Utilities do
         text = 'See <a href="IEV121-02-02">121-02-02</a>'
 
         expect(subject.parse_anchor_tag(text, "IEV"))
-          .to eq("See {{121-02-02, IEV:121-02-02}}")
+          .to eq("See {{121-02-02, urn:iec:std:iec:60050-121-02-02}}")
       end
 
       it "converts the a tag with quotes to asciidoc format" do
         text = "See <a href=IEV121-02-03>121-02-03</a>"
 
         expect(subject.parse_anchor_tag(text, "IEV"))
-          .to eq("See {{121-02-03, IEV:121-02-03}}")
+          .to eq("See {{121-02-03, urn:iec:std:iec:60050-121-02-03}}")
       end
     end
 
@@ -31,14 +31,14 @@ RSpec.describe Iev::Utilities do
         text = 'See <a href="IEV121-02-02">No end tag'
 
         expect(subject.parse_anchor_tag(text, "IEV"))
-          .to eq("See {{No end tag, IEV:121-02-02}}")
+          .to eq("See {{No end tag, urn:iec:std:iec:60050-121-02-02}}")
       end
 
       it "converts the a tag with quotes to asciidoc format" do
         text = "See <a href=IEV121-02-03>No end tag"
 
         expect(subject.parse_anchor_tag(text, "IEV"))
-          .to eq("See {{No end tag, IEV:121-02-03}}")
+          .to eq("See {{No end tag, urn:iec:std:iec:60050-121-02-03}}")
       end
     end
 
@@ -48,21 +48,21 @@ RSpec.describe Iev::Utilities do
         text = 'See <a href="IEV702-07-781">IEV 702-07-781</a>'
 
         expect(subject.parse_anchor_tag(text, "IEV"))
-          .to eq("See {{IEV 702-07-781, IEV:702-07-781}}")
+          .to eq("See {{IEV 702-07-781, urn:iec:std:iec:60050-702-07-781}}")
       end
 
       it "converts IEV link with multiline content" do
         text = "See <a href=\"IEV702-07-781\">IEV\n702-07-781</a> for the noun"
 
         expect(subject.parse_anchor_tag(text, "IEV"))
-          .to eq("See {{IEV\n702-07-781, IEV:702-07-781}} for the noun")
+          .to eq("See {{IEV\n702-07-781, urn:iec:std:iec:60050-702-07-781}} for the noun")
       end
 
       it "converts href without IEV prefix and 3-2-3 code" do
         text = '<a href="103-05-02">adjective</a>'
 
         expect(subject.parse_anchor_tag(text, "IEV"))
-          .to eq("{{adjective, IEV:103-05-02}}")
+          .to eq("{{adjective, urn:iec:std:iec:60050-103-05-02}}")
       end
     end
 
@@ -72,7 +72,7 @@ RSpec.describe Iev::Utilities do
         text = 'See <a href=IEV 102-01-10>IEV 102-01-10</a>'
 
         expect(subject.parse_anchor_tag(text, "103"))
-          .to eq("See {{IEV 102-01-10, IEV:102-01-10}}")
+          .to eq("See {{IEV 102-01-10, urn:iec:std:iec:60050-102-01-10}}")
       end
     end
 


### PR DESCRIPTION
Change IEV concept mention format from `{{term, IEV:code}}` to `{{term, urn:iec:std:iec:60050-code}}` for unified concept mention resolution.

Part of glossarist-ruby PR #152 (feat/gcr-concept-mentions).

## Changes

- `lib/iev/utilities.rb`: Update `convert_link` to generate URN-format mentions
- Updated test expectations in `utilities_spec.rb` and 3 acceptance spec files

## Test plan

- [x] `bundle exec rspec` — 158 examples, 0 failures