### PR TITLE
chore: update glossarist dependency to main (gloss ontology transform)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,6 @@ gem "simplecov"
 
 gemspec
 
-# TODO: remove once glossarist 2.7.0 is released with domains migration
+# TODO: remove once glossarist 2.7.0 is released with gloss ontology transform
 gem "glossarist", git: "https://github.com/glossarist/glossarist-ruby.git",
-                 branch: "feat/metanorma-parity-designation-model"
+                 branch: "main"


### PR DESCRIPTION
## Summary

Updates the glossarist gem dependency from the old `feat/metanorma-parity-designation-model` branch to `main`, which now includes the full gloss ontology RDF serialization (replacing the old SKOS-only transform).

### What changed
- Gemfile: point glossarist to `main` branch instead of old feature branch
- All 173 tests pass against the updated glossarist gem
- No code changes needed — the public model API is backward compatible

### Testing
- `bundle exec rspec`: 173 examples, 0 failures
- `bundle exec rubocop`: clean