### PR TITLE
chore: update .gitignore for output/ and sqlite3 fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,7 @@
 .vscode/
 
 /concepts/
+/output/
 Gemfile.lock
 TODO*
+spec/fixtures/*.sqlite3


### PR DESCRIPTION
## Summary

- Add `output/` and `spec/fixtures/*.sqlite3` to `.gitignore`
- These untracked files were generated by test runs and export commands

## Test plan
- [x] All 173 tests pass (`bundle exec rspec`)