### PR TITLE
chore: use released glossarist 2.8.2, remove git source pins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,17 +2,12 @@
 
 source "https://rubygems.org"
 
-# Tags support requires glossarist with ManagedConceptData#tags attribute.
-# Use local path when available, otherwise git source (until gem release).
+# Use local glossarist-ruby when available for development.
+# Otherwise falls back to released gem (requires >= 2.8.2 for tags support).
 if File.directory?(File.expand_path("../glossarist-ruby", __dir__))
   gem "glossarist", path: "../glossarist-ruby"
-  gem "lutaml-store", path: "../../lutaml/lutaml-store" if
-    File.directory?(File.expand_path("../../lutaml/lutaml-store", __dir__))
 else
-  gem "glossarist", git: "https://github.com/glossarist/glossarist-ruby",
-                    ref: "e6a12ff"
-  gem "lutaml-store", git: "https://github.com/lutaml/lutaml-store",
-                      ref: "3ce3f66"
+  gem "glossarist", ">= 2.8.2"
 end
 
 gem "benchmark"

--- a/iev.gemspec
+++ b/iev.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "creek", "~> 2.6"
   spec.add_dependency "ferrum", "~> 0.15"
-  spec.add_dependency "glossarist", ">= 2.8.1"
+  spec.add_dependency "glossarist", ">= 2.8.2"
   spec.add_dependency "lutaml-model", "~> 0.8.0"
   spec.add_dependency "nokogiri", "~> 1.19"
   spec.add_dependency "plurimath"


### PR DESCRIPTION
Glossarist 2.8.2 is released with `ManagedConceptData#tags`. Remove the git source fallback and lutaml-store pin from Gemfile. Bump gemspec minimum to `>= 2.8.2`.